### PR TITLE
Update LLM proxy example to use dynamic forwarding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,13 +99,8 @@ up-test: build-base
 down-test:
 	docker compose down --volumes
 
-.PHONY: integration-test-local
-integration-test-local: 
-	DD_TRACE_ENABLED=false \
-		uv run pytest -v tests/integration
-
 .PHONY: test
-test: unit-test integration-test down-test
+test: unit-test down-test integration-test down-test
 
 .PHONY: test-flake-finder
 test-flake-finder:

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ will run our first example, the "trivial" processor.
 * `examples.LLMProxyExtProcService`: This example demonstrates how to proxy requests to an LLM API by modifying request parameters and headers. It specifically handles streaming responses from LLM providers and shows how to implement an API proxy for model providers like OpenAI. To test this service with curl:
 
 ```bash
-curl -v "http://localhost:8080/completions" \
+curl -v "http://localhost:8080/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer test-key" \
   -d '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Hello"}], "stream": true}'

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -14,6 +14,7 @@ static_resources:
                 codec_type: AUTO
                 use_remote_address: true
                 stream_idle_timeout: 300s # 5 minutes timeout for streaming responses
+
                 access_log:
                   - name: envoy.access_loggers.stdout
                     typed_config:
@@ -21,6 +22,7 @@ static_resources:
                       log_format:
                         text_format_source:
                           inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\"\n"
+
                 route_config:
                   name: local_route
                   virtual_hosts:
@@ -35,15 +37,22 @@ static_resources:
                             envoy.filters.http.ext_proc:
                               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
                               disabled: true
+
                         - match:
-                            prefix: "/completions"
+                            prefix: "/v1"
                           route:
-                            cluster_header: "x-route-to"
+                            cluster: dynamic_forward_proxy
                             timeout: 60s
+                          typed_per_filter_config:
+                            envoy.filters.http.dynamic_forward_proxy:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.PerRouteConfig
+                              host_rewrite_header: "x-route-to"
+
                         - match:
                             prefix: "/"
                           route:
                             cluster: upstream
+
                 http_filters:
                   - name: envoy.filters.http.ext_proc
                     typed_config:
@@ -61,6 +70,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -77,6 +87,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -93,6 +104,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -109,6 +121,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -125,6 +138,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -141,6 +155,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -157,6 +172,7 @@ static_resources:
                         response_body_mode: BUFFERED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -173,10 +189,61 @@ static_resources:
                         response_body_mode: STREAMED
                         request_trailer_mode: SKIP
                         response_trailer_mode: SKIP
+
+                  - name: envoy.filters.http.dynamic_forward_proxy
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+                      dns_cache_config:
+                        name: dynamic_forward_proxy_cache
+                        dns_lookup_family: V4_ONLY
+                        typed_dns_resolver_config:
+                          name: envoy.network.dns_resolver.cares
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig
+                            resolvers:
+                              - socket_address:
+                                  address: 127.0.0.11 # Docker DNS
+                                  port_value: 53
+                            dns_resolver_options:
+                              use_tcp_for_dns_lookups: true
+                              no_default_search_domain: true
+
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                      # suppress_envoy_headers: false
   clusters:
+    # Dynamic forwarding proxy to LLM providers
+    - name: dynamic_forward_proxy
+      lb_policy: CLUSTER_PROVIDED
+      cluster_type:
+        name: envoy.clusters.dynamic_forward_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+          dns_cache_config:
+            name: dynamic_forward_proxy_cache
+            dns_lookup_family: V4_ONLY
+            typed_dns_resolver_config:
+              name: envoy.network.dns_resolver.cares
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig
+                resolvers:
+                  - socket_address:
+                      address: 127.0.0.11 # Docker DNS
+                      port_value: 53
+                dns_resolver_options:
+                  use_tcp_for_dns_lookups: true
+                  no_default_search_domain: true
+      # This cluster would include a config.core.v3.TransportSocket for TLS
+      # https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-transportsocket
+      # transport_socket:
+      #   name: envoy.transport_sockets.tls
+      #   typed_config:
+      #     "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      #     common_tls_context:
+      #       validation_context:
+      #         trusted_ca: {filename: /etc/ssl/certs/ca-certificates.crt}
+
     - name: listener
       connect_timeout: 0.250s
       type: LOGICAL_DNS
@@ -196,6 +263,20 @@ static_resources:
                     socket_address:
                       address: localhost
                       port_value: 8000
+
+    - name: envoy-stat
+      connect_timeout: 0.25s
+      type: STATIC
+      load_assignment:
+        cluster_name: envoy-stat
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 9901
+
     - name: upstream
       connect_timeout: 0.250s
       type: LOGICAL_DNS
@@ -217,68 +298,6 @@ static_resources:
                       address: upstream
                       port_value: 80
 
-    - name: streaming
-      connect_timeout: 0.250s
-      type: LOGICAL_DNS
-      lb_policy: LEAST_REQUEST
-      dns_lookup_family: V4_ONLY
-      typed_extension_protocol_options:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          explicit_http_config:
-            http_protocol_options: {}
-      load_assignment:
-        cluster_name: default_llm_provider
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  hostname: streaming
-                  address:
-                    socket_address:
-                      address: streaming
-                      port_value: 80
-
-    - name: openai
-      connect_timeout: 0.250s
-      type: LOGICAL_DNS
-      lb_policy: LEAST_REQUEST
-      dns_lookup_family: V4_ONLY
-      typed_extension_protocol_options:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          explicit_http_config:
-            http_protocol_options: {}
-      load_assignment:
-        cluster_name: openai
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  hostname: openai
-                  address:
-                    socket_address:
-                      address: openai
-                      port_value: 80
-
-    - name: anthropic
-      connect_timeout: 0.250s
-      type: LOGICAL_DNS
-      lb_policy: LEAST_REQUEST
-      dns_lookup_family: V4_ONLY
-      typed_extension_protocol_options:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          explicit_http_config:
-            http_protocol_options: {}
-      load_assignment:
-        cluster_name: anthropic
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  hostname: anthropic
-                  address:
-                    socket_address:
-                      address: anthropic
-                      port_value: 80
     - name: trivial
       dns_lookup_family: V4_ONLY
       lb_policy: LEAST_REQUEST

--- a/envoy_extproc_sdk/extproc.py
+++ b/envoy_extproc_sdk/extproc.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from asyncio import CancelledError, iscoroutinefunction
 from enum import Enum
-from logging import getLogger
+from logging import getLogger, Logger
 from typing import (
     AsyncGenerator,
     AsyncIterator,
@@ -84,8 +84,9 @@ class BaseExtProcService(EnvoyExtProcServicer):
         "content-length": "content_length",
     }
 
-    def __init__(self, name: Optional[str] = None) -> None:
+    def __init__(self, name: Optional[str] = None, logger: Optional[Logger] = None ) -> None:
         self.name = name or self.__class__.__name__
+        self.logger = logger or getLogger(__name__)
 
     def __repr__(self) -> str:
         """Get this object's \"name\", either class name or overriden"""

--- a/envoy_extproc_sdk/extproc.py
+++ b/envoy_extproc_sdk/extproc.py
@@ -57,9 +57,7 @@ class StopRequestProcessing(Exception):
     respond from cache after seeing the request headers and
     body."""
 
-    def __init__(
-        self, response: ext_api.ImmediateResponse, reason: Optional[str] = None
-    ) -> None:
+    def __init__(self, response: ext_api.ImmediateResponse, reason: Optional[str] = None) -> None:
         self.response = response
         self.reason = reason
 
@@ -84,7 +82,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
         "content-length": "content_length",
     }
 
-    def __init__(self, name: Optional[str] = None, logger: Optional[Logger] = None ) -> None:
+    def __init__(self, name: Optional[str] = None, logger: Optional[Logger] = None) -> None:
         self.name = name or self.__class__.__name__
         self.logger = logger or getLogger(__name__)
 
@@ -186,14 +184,10 @@ class BaseExtProcService(EnvoyExtProcServicer):
                             else None
                         )
                         if phase == "request_headers":
-                            result = ext_api.ProcessingResponse(
-                                request_headers=headers_response
-                            )
+                            result = ext_api.ProcessingResponse(request_headers=headers_response)
                             yield result
                         elif phase == "response_headers":
-                            result = ext_api.ProcessingResponse(
-                                response_headers=headers_response
-                            )
+                            result = ext_api.ProcessingResponse(response_headers=headers_response)
                             yield result
                     elif phase.endswith("body"):
                         body_response = ext_api.BodyResponse(
@@ -202,14 +196,10 @@ class BaseExtProcService(EnvoyExtProcServicer):
                             else None
                         )
                         if phase == "request_body":
-                            result = ext_api.ProcessingResponse(
-                                request_body=body_response
-                            )
+                            result = ext_api.ProcessingResponse(request_body=body_response)
                             yield result
                         elif phase == "response_body":
-                            result = ext_api.ProcessingResponse(
-                                response_body=body_response
-                            )
+                            result = ext_api.ProcessingResponse(response_body=body_response)
                             yield result
                     else:  # endswith("trailers") == True
                         trailers_response = ext_api.TrailersResponse(
@@ -218,14 +208,10 @@ class BaseExtProcService(EnvoyExtProcServicer):
                             else None
                         )
                         if phase == "request_trailers":
-                            result = ext_api.ProcessingResponse(
-                                request_trailers=trailers_response
-                            )
+                            result = ext_api.ProcessingResponse(request_trailers=trailers_response)
                             yield result
                         elif phase == "response_trailers":
-                            result = ext_api.ProcessingResponse(
-                                response_trailers=trailers_response
-                            )
+                            result = ext_api.ProcessingResponse(response_trailers=trailers_response)
                             yield result
 
                 except StopRequestProcessing as err:
@@ -240,9 +226,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
                         },
                     )
                     immediate_response = err.response
-                    result = ext_api.ProcessingResponse(
-                        immediate_response=immediate_response
-                    )
+                    result = ext_api.ProcessingResponse(immediate_response=immediate_response)
                     yield result
 
     async def safe_iterator(
@@ -322,9 +306,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
     #       ...
     #
 
-    def process(
-        self, phase: ExtProcPhase
-    ) -> Callable[[ExtProcHandler], ExtProcHandler]:
+    def process(self, phase: ExtProcPhase) -> Callable[[ExtProcHandler], ExtProcHandler]:
         def wrapper(func: ExtProcHandler) -> ExtProcHandler:
             setattr(self, f"process_{phase}", func)
             return getattr(self, f"process_{phase}")
@@ -403,16 +385,12 @@ class BaseExtProcService(EnvoyExtProcServicer):
     @staticmethod
     def just_continue_headers() -> ext_api.HeadersResponse:
         """generic "move on" headers response object (can be modified)"""
-        return ext_api.HeadersResponse(
-            response=BaseExtProcService.just_continue_response()
-        )
+        return ext_api.HeadersResponse(response=BaseExtProcService.just_continue_response())
 
     @staticmethod
     def just_continue_body() -> ext_api.BodyResponse:
         """generic "move on" body response object (can be modified)"""
-        return ext_api.BodyResponse(
-            response=BaseExtProcService.just_continue_response()
-        )
+        return ext_api.BodyResponse(response=BaseExtProcService.just_continue_response())
 
     @staticmethod
     def just_continue_trailers() -> ext_api.TrailersResponse:
@@ -478,9 +456,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
         """get multiple header values by name (envoy uses lower cased names)"""
 
         if isinstance(names, list):  # enforce dictionary input
-            return BaseExtProcService.get_headers(
-                headers, dict(names), lower_cased=lower_cased
-            )
+            return BaseExtProcService.get_headers(headers, dict(names), lower_cased=lower_cased)
 
         if not lower_cased:  # enforce lower-cased keys
             keys = {k.lower(): v for k, v in names.items()}
@@ -498,9 +474,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
     ) -> ext_api.CommonResponse:
         """add a header to a CommonResponse"""
         header = EnvoyHeaderValue(key=key, value=value)
-        response.header_mutation.set_headers.append(
-            EnvoyHeaderValueOption(header=header)
-        )
+        response.header_mutation.set_headers.append(EnvoyHeaderValueOption(header=header))
         return response
 
     @staticmethod
@@ -510,9 +484,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
     ) -> ext_api.CommonResponse:
         """add a set of headers to a CommonResponse"""
         if isinstance(headers, dict):
-            return BaseExtProcService.add_headers(
-                response, [(k, v) for k, v in headers.items()]
-            )
+            return BaseExtProcService.add_headers(response, [(k, v) for k, v in headers.items()])
         response.header_mutation.set_headers.extend(
             [
                 EnvoyHeaderValueOption(header=EnvoyHeaderValue(key=key, value=value))
@@ -522,9 +494,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
         return response
 
     @staticmethod
-    def remove_header(
-        response: ext_api.CommonResponse, name: str
-    ) -> ext_api.CommonResponse:
+    def remove_header(response: ext_api.CommonResponse, name: str) -> ext_api.CommonResponse:
         """remove a header from a CommonResponse"""
         response.header_mutation.remove_headers.append(name)
         return response
@@ -570,9 +540,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
         """
 
         header: EnvoyHeaderValueOption
-        filters_header = self.get_header(
-            headers, EXTPROCS_APPLIED_HEADER, lower_cased=True
-        )
+        filters_header = self.get_header(headers, EXTPROCS_APPLIED_HEADER, lower_cased=True)
         if filters_header:
             header = EnvoyHeaderValueOption(
                 header=EnvoyHeaderValue(
@@ -582,9 +550,7 @@ class BaseExtProcService(EnvoyExtProcServicer):
             )
         else:
             header = EnvoyHeaderValueOption(
-                header=EnvoyHeaderValue(
-                    key=EXTPROCS_APPLIED_HEADER, value=f"{self.name}"
-                )
+                header=EnvoyHeaderValue(key=EXTPROCS_APPLIED_HEADER, value=f"{self.name}")
             )
 
         # We only support CommonResponse here now

--- a/examples/echo.py
+++ b/examples/echo.py
@@ -58,7 +58,7 @@ class EchoExtProcService(BaseExtProcService):
 
         headers = request["request_headers"].copy()
         headers["content-type"] = "application/json"
-        
+
         immediate_response = self.form_immediate_response(
             EnvoyHttpStatusCode.OK, headers, json.dumps(response_body)
         )

--- a/examples/llm_proxy.py
+++ b/examples/llm_proxy.py
@@ -9,27 +9,43 @@
 # 4. Allows streaming responses to flow through unmodified
 
 import json
-import logging
-from typing import Dict
+from logging import getLogger
+from typing import Any, Dict
 
 from envoy_extproc_sdk import BaseExtProcService, ext_api, serve
 from grpc import ServicerContext
 
+
 LLM_PROXY_HEADER = "x-llm-proxy"
-TARGET_ENDPOINT = "/completions"
+TARGET_ENDPOINT = "/v1"
 TARGET_MODEL_HEADER = "x-target-model"
 ROUTE_HEADER = "x-route-to"
 
-# Model to destination mapping
-MODEL_ROUTES = {
-    "gpt-3.5-turbo": "openai",
-    "gpt-4o": "openai",
-    "claude-3.5-sonnet": "anthropic",
-    "claude-3.7-sonnet": "anthropic",
-    "default": "default_llm_provider",
+# Model to destination mapping - using container hostnames for Docker DNS resolution
+
+MODEL_MAPPINGS: Dict[str, Any] = {
+    "gpt-3.5-turbo": {
+        "inference_provider_id": "openai",
+        "inference_provider_url": "openai:80",
+        "inference_provider_model": "gpt-4o",
+    },
+    "claude-3.5-sonnet": {
+        "inference_provider_id": "anthropic",
+        "inference_provider_url": "anthropic:80",
+        "inference_provider_model": "claude-3.7-sonnet",
+    },
+    "default": {
+        "inference_provider_id": "streaming",
+        "inference_provider_url": "streaming:80",
+        "inference_provider_model": "default-model",
+    },
 }
 
-logger = logging.getLogger(__name__)
+# Path rewrite mapping based on inference service provider
+PATH_REWRITES: Dict[str, Dict[str, str]] = {
+    "openai": {},
+    "anthropic": {"/v1/chat/completions": "/v1/messages"},
+}
 
 
 class LLMProxyExtProcService(BaseExtProcService):
@@ -40,23 +56,24 @@ class LLMProxyExtProcService(BaseExtProcService):
         request: Dict,
         response: ext_api.CommonResponse,
     ) -> ext_api.CommonResponse:
-        # Skip processing if not specifically targeting completions endpoint
-        if not request.get("path", "").endswith(TARGET_ENDPOINT):
+        # Skip processing if not specifically targeting v1 endpoint
+        if not request.get("path", "").startswith(TARGET_ENDPOINT):
             return response
 
         # Store content-type to check if JSON in body phase
         content_type = self.get_header(headers, "content-type")
         request["content_type"] = content_type
 
-        # this is unused, using dynamic routing based on ROUTE_HEADER
-        self.add_header(response, "x-target-host", "api.openai.com")
+        # Store the original path for possible rewriting later
+        request["original_path"] = request.get("path", "")
+        self.logger.debug(f"Setting original path context: {request['original_path']}")
 
         # Replace the Authorization header
         auth_header = self.get_header(headers, "authorization")
         if auth_header:
             self.remove_header(response, "authorization")
             self.add_header(response, "authorization", "Bearer sk-proxy-key-replaced")
-            logger.debug("Replaced Authorization header")
+            self.logger.debug("Replaced Authorization header")
 
         # Add a marker header to indicate this request was proxied
         self.add_header(response, LLM_PROXY_HEADER, "true")
@@ -70,13 +87,17 @@ class LLMProxyExtProcService(BaseExtProcService):
         request: Dict,
         response: ext_api.CommonResponse,
     ) -> ext_api.CommonResponse:
-        if not request["path"].endswith(TARGET_ENDPOINT):
+        original_path = request.get("original_path", "")
+        if not original_path.startswith(TARGET_ENDPOINT):
             return response
 
-        if request.get("content_type") and "application/json" in request["content_type"]:
+        if (
+            request.get("content_type")
+            and "application/json" in request["content_type"]
+        ):
             try:
                 body_str = body.body.decode("utf-8")
-                logger.debug(f"ORIGINAL BODY: {body_str}")
+                self.logger.debug(f"ORIGINAL BODY: {body_str}")
                 json_body = json.loads(body_str)
 
                 # Track modifications
@@ -89,27 +110,51 @@ class LLMProxyExtProcService(BaseExtProcService):
 
                     # Set routing headers based on the model
                     self.add_header(response, TARGET_MODEL_HEADER, original_model)
-                    target_route = MODEL_ROUTES.get(original_model, MODEL_ROUTES["default"])
+                    model_mapping = MODEL_MAPPINGS.get(
+                        original_model, MODEL_MAPPINGS["default"]
+                    )
+                    target_route = model_mapping.get("inference_provider_url", "")
                     self.add_header(response, ROUTE_HEADER, target_route)
+
+                    # We can't directly set host/authority headers,
+                    # but Envoy will use x-route-to for host rewriting
+                    # based on our route configuration's host_rewrite_header
+
+                    # Save target route for path rewriting
+                    request["target_route"] = target_route
+
                     # Clear the route cache for the current client request.
                     # We modified headers that are used to calculate the route.
                     response.clear_route_cache = True
 
                     # Modify model parameter based on target route
-                    if target_route == "openai":
-                        json_body["model"] = "gpt-4o"
-                    elif target_route == "anthropic":
-                        json_body["model"] = "claude-3.7-sonnet"
+                    json_body["model"] = model_mapping.get(
+                        "inference_provider_model", ""
+                    )
 
                     modified = True
-                    logger.info(
+                    self.logger.info(
                         f"Routing {original_model} to {target_route} as {json_body['model']}"
                     )
+
+                    # Check if we need to rewrite the path
+                    path_rewrites = PATH_REWRITES.get(
+                        model_mapping["inference_provider_id"], {}
+                    )
+                    for old_path, new_path in path_rewrites.items():
+                        if old_path in original_path:
+                            new_request_path = original_path.replace(old_path, new_path)
+                            self.logger.info(
+                                f"Rewriting path from {original_path} to {new_request_path}"
+                            )
+                            self.add_header(response, ":path", new_request_path)
+                            request["path"] = new_request_path
+                            break
 
                 if modified:
                     new_body = json.dumps(json_body).encode("utf-8")
 
-                    logger.debug(f"MODIFIED BODY SENT: {new_body.decode('utf-8')}")
+                    self.logger.debug(f"MODIFIED BODY SENT: {new_body.decode('utf-8')}")
 
                     response.body_mutation.body = new_body
 
@@ -119,7 +164,7 @@ class LLMProxyExtProcService(BaseExtProcService):
                     request["body_modified"] = True
 
             except (json.JSONDecodeError, UnicodeDecodeError):
-                logger.warning("Failed to decode JSON body")
+                self.logger.warning("Failed to decode JSON body")
                 pass
         return response
 
@@ -130,9 +175,14 @@ class LLMProxyExtProcService(BaseExtProcService):
         request: Dict,
         response: ext_api.CommonResponse,
     ) -> ext_api.CommonResponse:
-        if not request.get("path", "").endswith(TARGET_ENDPOINT):
+        original_path = request.get("original_path", "")
+        if not original_path.startswith(TARGET_ENDPOINT):
             return response
 
+        self.logger.debug(
+            f"""Processing response headers for path: {original_path} 
+            with context: {request} and headers: {headers}"""
+        )
         # Add proxy header to response
         self.add_header(response, LLM_PROXY_HEADER, "true")
 
@@ -140,17 +190,27 @@ class LLMProxyExtProcService(BaseExtProcService):
         if "original_model" in request:
             self.add_header(response, "x-original-model", request["original_model"])
 
+        # Add route information for testing purposes
+        if "target_route" in request:
+            self.add_header(response, "x-route-to", request["target_route"])
+
+        if original_path != request.get("path", ""):
+            self.add_header(response, "x-path-rewritten", "true")
+
         # Check if this is a streaming response (for demo/debug purposes)
         content_type = self.get_header(headers, "content-type")
         if content_type and "text/event-stream" in content_type.lower():
-            logger.debug("Detected streaming response with content-type: %s", content_type)
+            self.logger.debug(
+                "Detected streaming response with content-type: %s", content_type
+            )
         return response
 
 
+def run_processing_server():
+    logger = getLogger(__name__)
+    logger.info("Starting LLM Proxy ExtProc service...")
+    serve(service=LLMProxyExtProcService(logger=logger))
+
+
 if __name__ == "__main__":
-    import logging
-
-    FORMAT = "%(asctime)s : %(levelname)s : %(message)s"
-    logging.basicConfig(level=logging.INFO, format=FORMAT, handlers=[logging.StreamHandler()])
-
-    serve(service=LLMProxyExtProcService())
+    run_processing_server()

--- a/examples/llm_proxy.py
+++ b/examples/llm_proxy.py
@@ -15,7 +15,6 @@ from typing import Any, Dict
 from envoy_extproc_sdk import BaseExtProcService, ext_api, serve
 from grpc import ServicerContext
 
-
 LLM_PROXY_HEADER = "x-llm-proxy"
 TARGET_ENDPOINT = "/v1"
 TARGET_MODEL_HEADER = "x-target-model"
@@ -91,10 +90,7 @@ class LLMProxyExtProcService(BaseExtProcService):
         if not original_path.startswith(TARGET_ENDPOINT):
             return response
 
-        if (
-            request.get("content_type")
-            and "application/json" in request["content_type"]
-        ):
+        if request.get("content_type") and "application/json" in request["content_type"]:
             try:
                 body_str = body.body.decode("utf-8")
                 self.logger.debug(f"ORIGINAL BODY: {body_str}")
@@ -110,9 +106,7 @@ class LLMProxyExtProcService(BaseExtProcService):
 
                     # Set routing headers based on the model
                     self.add_header(response, TARGET_MODEL_HEADER, original_model)
-                    model_mapping = MODEL_MAPPINGS.get(
-                        original_model, MODEL_MAPPINGS["default"]
-                    )
+                    model_mapping = MODEL_MAPPINGS.get(original_model, MODEL_MAPPINGS["default"])
                     target_route = model_mapping.get("inference_provider_url", "")
                     self.add_header(response, ROUTE_HEADER, target_route)
 
@@ -128,9 +122,7 @@ class LLMProxyExtProcService(BaseExtProcService):
                     response.clear_route_cache = True
 
                     # Modify model parameter based on target route
-                    json_body["model"] = model_mapping.get(
-                        "inference_provider_model", ""
-                    )
+                    json_body["model"] = model_mapping.get("inference_provider_model", "")
 
                     modified = True
                     self.logger.info(
@@ -138,9 +130,7 @@ class LLMProxyExtProcService(BaseExtProcService):
                     )
 
                     # Check if we need to rewrite the path
-                    path_rewrites = PATH_REWRITES.get(
-                        model_mapping["inference_provider_id"], {}
-                    )
+                    path_rewrites = PATH_REWRITES.get(model_mapping["inference_provider_id"], {})
                     for old_path, new_path in path_rewrites.items():
                         if old_path in original_path:
                             new_request_path = original_path.replace(old_path, new_path)
@@ -200,9 +190,7 @@ class LLMProxyExtProcService(BaseExtProcService):
         # Check if this is a streaming response (for demo/debug purposes)
         content_type = self.get_header(headers, "content-type")
         if content_type and "text/event-stream" in content_type.lower():
-            self.logger.debug(
-                "Detected streaming response with content-type: %s", content_type
-            )
+            self.logger.debug("Detected streaming response with content-type: %s", content_type)
         return response
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 @pytest_asyncio.fixture
 async def http_client() -> AsyncGenerator[AsyncClient, None]:
     """Fixture for async HTTP client to test the Envoy ExtProc services through Envoy proxy."""
-    async with AsyncClient(base_url="http://localhost:8080", timeout=30.0) as client:
+    async with AsyncClient(base_url="http://localhost:8080", timeout=10.0) as client:
         yield client
 
 

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -223,7 +223,7 @@ async def test_llm_proxy_service_streaming(
         # Check routing header was set
         assert "x-route-to" in response.headers
         assert response.headers["x-route-to"] == expected_route
-        
+
         # For Anthropic, we should see path rewriting
         if "anthropic" in expected_route:
             assert "x-path-rewritten" in response.headers

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -180,8 +180,8 @@ async def test_context_service(http_client: AsyncClient, request_id: str):
 @pytest.mark.parametrize(
     "model,expected_route,expected_provider_model",
     [
-        ("gpt-3.5-turbo", "openai", "gpt-4o"),
-        ("claude-3.5-sonnet", "anthropic", "claude-3.7-sonnet"),
+        ("gpt-3.5-turbo", "openai:80", "gpt-4o"),
+        ("claude-3.5-sonnet", "anthropic:80", "claude-3.7-sonnet"),
     ],
 )
 async def test_llm_proxy_service_streaming(
@@ -198,9 +198,10 @@ async def test_llm_proxy_service_streaming(
         "stream": True,
     }
 
+    # Test the dynamic forward proxy routing
     async with http_client.stream(
         "POST",
-        "/completions",
+        "/v1/chat/completions",
         json=test_data,
         headers={
             "content-type": "application/json",
@@ -219,9 +220,14 @@ async def test_llm_proxy_service_streaming(
         assert "x-original-model" in response.headers
         assert response.headers["x-original-model"] == model
 
-        # # Check routing header was set
+        # Check routing header was set
         assert "x-route-to" in response.headers
         assert response.headers["x-route-to"] == expected_route
+        
+        # For Anthropic, we should see path rewriting
+        if "anthropic" in expected_route:
+            assert "x-path-rewritten" in response.headers
+            assert response.headers["x-path-rewritten"] == "true"
 
         full_response = ""
         async for chunk in response.aiter_text():
@@ -243,4 +249,5 @@ async def test_llm_proxy_service_streaming(
 
         # Verify the model was changed in the response chunks
         assert f'"model": "{expected_provider_model}"' in full_response
-        assert f'"provider": "{expected_route}"' in full_response
+        expected_provider = expected_route.split(":")[0]
+        assert f'"provider": "{expected_provider}"' in full_response

--- a/tests/mocks/streaming/streaming.py
+++ b/tests/mocks/streaming/streaming.py
@@ -76,10 +76,8 @@ class StreamingHandler(http.server.BaseHTTPRequestHandler):
         except json.JSONDecodeError:
             request_data = {}
 
-        path_is_completions = self.path.startswith("/completions")
-        is_streaming = (
-            path_is_completions  # Force streaming for all completions requests for this example
-        )
+        # Force streaming for all requests for this example
+        is_streaming = True
 
         logger.debug(f"Received request: path={self.path}")
         logger.debug(f"RECEIVED BODY: {body}")


### PR DESCRIPTION
## Description
 <!-- What does this pull request accomplish? -->
This PR updates the LLM proxying example to use dynamic forwarding instead of hardcoding cluster configurations for each AI inference provider upstream. This approach provides greater flexibility by:

  1. Using Envoy's dynamic forward proxy to route requests based on a model ID in the request body
  2. Adding host rewriting via headers to support multiple AI inference providers
  3. Supporting path rewriting for different inference provider API endpoints

  ## Additional Details
 <!-- Add any additional context, screenshots or attachments relevant to the pull request here. -->
This implementation allows for easier addition of new AI inference provides without requiring Envoy configuration changes. The code now dynamically routes requests based on the requested model, rewrites paths as needed for different provider APIs (like mapping OpenAI-style endpoints to Anthropic endpoints), and preserves streaming response functionality.

The changes include updates to both the example code and the Envoy configuration to support the dynamic forwarding approach.